### PR TITLE
hotfix: split rofi theme config

### DIFF
--- a/config/rofi/config.rasi
+++ b/config/rofi/config.rasi
@@ -53,7 +53,6 @@ configuration {
 /*	window-format: "{w}    {c}   {t}";*/
 /*	click-to-exit: true;*/
 /*	show-match: true;*/
-	theme: "Arc-Dark";
 /*	color-normal: ;*/
 /*	color-urgent: ;*/
 /*	color-active: ;*/
@@ -143,5 +142,7 @@ configuration {
 /*	me-accept-entry: "MouseDPrimary";*/
 /*	me-accept-custom: "Control+MouseDPrimary";*/
 }
+
+@theme "Arc-Dark"
 
 /* vim:ft=css


### PR DESCRIPTION
#5 が勝手に閉じてカス duplicatedにも程がある